### PR TITLE
actions/checkout update to v5

### DIFF
--- a/.github/workflows/checkmarx.yaml
+++ b/.github/workflows/checkmarx.yaml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  #v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  #v5.0.0
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  #v5.0.0
 
       - name: 📦 Setup Bun
         uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
Upgrade checkout action to v5.0.0 and pin to hash as a security precaution.